### PR TITLE
Generative FHMM - categorical data

### DIFF
--- a/hela/generation/hmm/factored_model.py
+++ b/hela/generation/hmm/factored_model.py
@@ -160,7 +160,7 @@ class FactoredHMMGenerativeModel(HMMGenerativeModel):
         """
         random = self.random
         categorical_values = self.categorical_values
-        n_hidden_states = self.ns_hidden_states[0] ** len(self.ns_hidden_states)
+        n_hidden_states = np.prod(self.ns_hidden_states)
 
         values = list(categorical_values.index)
 


### PR DESCRIPTION
### Whats changed?
I updated the generative modelling for fhmm to include categorical data.  The updates are for the most part analogous to the generative modelling for HMM.

### How was it tested?
Created a notebook and tried varying values for `ns_hidden_states` and `n_categorical_features` which all seem to result in a reasonable emission matrix and generated data.