### PR TITLE
Generative fhmm - gaussian data flexibility

### DIFF
--- a/hela/generation/hmm/factored_model.py
+++ b/hela/generation/hmm/factored_model.py
@@ -185,8 +185,13 @@ class FactoredHMMGenerativeModel(HMMGenerativeModel):
         """ Returns array of means
 
         Returns:
-            Array where entry [m,d,n] is the contribution of hidden state n
+            Masked array where entry [m,d,n] is the contribution of hidden state n
             in hmm system m to gaussian dimension d.
+
+            If the number of hidden states are not the same for each system, n is
+            the max number of hidden states across all systems m.
+            A system with fewer than n states will have columns filled with masked
+            Nan entries.
         """
         means = []
         max_hidden_state = np.max(self.ns_hidden_states)
@@ -194,6 +199,7 @@ class FactoredHMMGenerativeModel(HMMGenerativeModel):
             weights = np.random.uniform(-3, 3, (self.n_gaussian_features, max_hidden_state))
             if n < max_hidden_state:
                 weights[:,n:] = np.nan
+            # Mask all Nan entries
             weights = np.ma.masked_invalid(weights)
             means.append(weights)
 


### PR DESCRIPTION
### What's this about?
Previously, generating Gaussian data with a varying number of hidden states between the HMM systems was not possible.  This adds flexibility to the generation of gaussian data so that the number of hidden states does not need to be consistent across all systems.

### What's changed?
`self.means` is now a masked array. For any system which has fewer hidden states than the max number of hidden states across systems, the additional columns which should be ignored are now filled with masked Nan entries.

### How was it tested?
I generated combinations of gaussian and categorical data with a varying number of hidden states within each system.